### PR TITLE
Document React Native CocoaPods workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,27 @@
 
 ## React Native
 
-To use this library on React Native, simply run
+To use this library on React Native, run `yarn add react-native-zcash` to install it. Then add these lines to your Podspec file, to work around certain compatiblity issues between the ZCash SDK and React Native:
+
+```ruby
+pod 'CNIOAtomics', :modular_headers => true
+pod 'CNIOBoringSSL', :modular_headers => true
+pod 'CNIOBoringSSLShims', :modular_headers => true
+pod 'CNIOLinux', :modular_headers => true
+pod 'CNIODarwin', :modular_headers => true
+pod 'CNIOHTTPParser', :modular_headers => true
+pod 'CNIOWindows', :modular_headers => true
+pod 'CGRPCZlib', :modular_headers => true
+pod 'ZcashLightClientKit', :git => 'https://github.com/zcash/ZcashLightClientKit.git', :commit => '74f3ae20f26748e162c051e5fa343c71febc4294'
+```
+
+Finally, you can use CocoaPods to integrate the library with your project:
 
 ```bash
-yarn add react-native-zcash
 cd ios
 pod install
 ```
 
 ## API overview
+
+TODO


### PR DESCRIPTION
These lines are necessary for a successful build, and there is no way to integrate them into our own podfile.