### PR TITLE
Copy the rust headers once the folder exists

### DIFF
--- a/scripts/updateSources.ts
+++ b/scripts/updateSources.ts
@@ -62,12 +62,6 @@ async function rebuildXcframework(): Promise<void> {
       'tmp/zcash-light-client-ffi/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/libzcashlc'
     )
   )
-  await disklet.setText(
-    'ios/ZCashLightClientKit/Rust/zcashlc.h',
-    await disklet.getText(
-      'tmp/zcash-light-client-ffi/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h'
-    )
-  )
 
   // Build the XCFramework:
   loudExec(tmp, [
@@ -117,6 +111,14 @@ async function copySwift(): Promise<void> {
 
     await toDisklet.setText(file, fixed)
   }
+
+  // Copy the Rust header into the Swift location:
+  await disklet.setText(
+    'ios/ZCashLightClientKit/Rust/zcashlc.h',
+    await disklet.getText(
+      'tmp/zcash-light-client-ffi/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h'
+    )
+  )
 }
 
 /**


### PR DESCRIPTION
Before, we would copy the headers and then delete the folder. Now we copy the headers after the folder has been recreated.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
