### PR TITLE
Stop using the iOS SQLite library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Stop depending on the iOS-provided SQLite, which causes crashes on iOS 13-15 because it is too old.
+
 ## 0.7.0 (2024-04-22)
 
 - added: Support Orchard pool

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pod 'CNIODarwin', :modular_headers => true
 pod 'CNIOHTTPParser', :modular_headers => true
 pod 'CNIOLinux', :modular_headers => true
 pod 'CNIOWindows', :modular_headers => true
+pod 'sqlite3', :modular_headers => true
 ```
 
 On the Android side, you may need to configure an explicit Kotlin version, so all your native dependencies will be compatible with one another. Simply define `kotlinVersion` in your `android/build.gradle` file:

--- a/react-native-zcash.podspec
+++ b/react-native-zcash.podspec
@@ -28,6 +28,6 @@ Pod::Spec.new do |s|
 
   s.dependency "MnemonicSwift", "~> 2.2"
   s.dependency "gRPC-Swift", "~> 1.8"
-  s.dependency "SQLite.swift", "~> 0.12"
+  s.dependency "SQLite.swift/standalone", "~> 0.14"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
In order to work correctly, the Rust FFI code needs to link against SQLite >= 3.37.0. The way we satisfy this dependency is to include the SQLite.swift Pod, which in turn depends on the iOS-provided SQLite library. Unfortunately, iOS does not ship with a new enough SQLite until iOS 16, but we claim to support iOS 13.

To fix this problem, we need to bring our own version of SQLite, which is newer that the OS-provided one. Fortunately, the SQLite.swift library provides a way to do this - we just include the "/standalone" subspec.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Also review https://github.com/EdgeApp/react-native-piratechain/pull/10, which is an identical change in react-native-priatechain.

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207181768458859