### PR TITLE
Do not emit events until JavaScript is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Pause synchronizer events until JavaScript is ready to receive them.
+
 ## 0.7.1 (2024-05-11)
 
 - fixed: Stop depending on the iOS-provided SQLite, which causes crashes on iOS 13-15 because it is too old.

--- a/ios/RNZcash.swift
+++ b/ios/RNZcash.swift
@@ -72,6 +72,7 @@ let genericError = NSError(domain: "", code: 0)
 
 @objc(RNZcash)
 class RNZcash: RCTEventEmitter {
+  var hasListeners: Bool = false
 
   override static func requiresMainQueueSetup() -> Bool {
     return true
@@ -440,7 +441,17 @@ class RNZcash: RCTEventEmitter {
 
   // Events
   public func sendToJs(name: String, data: Any) {
-    self.sendEvent(withName: name, body: data)
+    if (hasListeners) {
+      self.sendEvent(withName: name, body: data)
+    }
+  }
+
+  override func startObserving() -> Void {
+    hasListeners = true
+  }
+
+  override func stopObserving() -> Void {
+    hasListeners = false
   }
 
   override func supportedEvents() -> [String] {


### PR DESCRIPTION
If the synchronizer is running in the background, but the app does a hot-reload, we need to stop sending events until JavaScript is ready again.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

Same thing for priatechain: https://github.com/EdgeApp/react-native-piratechain/pull/11

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207319749532362