### PR TITLE
Help CocoaPods find our missing header file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /android/build/
 /ios/libzcashlc.xcframework/
 /ios/ZCashLightClientKit/
+/ios/zcashlc.h
 /lib/
 /tmp/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Add a missing header file to the podspec.
+
 ## 0.7.2 (2024-05-17)
 
 - fixed: Pause synchronizer events until JavaScript is ready to receive them.

--- a/ios/react-native-zcash-Bridging-Header.h
+++ b/ios/react-native-zcash-Bridging-Header.h
@@ -1,2 +1,2 @@
 #import <React/RCTEventEmitter.h>
-#include "ZCashLightClientKit/Rust/zcashlc.h"
+#include "zcashlc.h"

--- a/react-native-zcash.podspec
+++ b/react-native-zcash.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
     "ios/react-native-zcash-Bridging-Header.h",
     "ios/RNZcash.m",
     "ios/RNZcash.swift",
+    "ios/zcashlc.h",
     "ios/ZCashLightClientKit/**/*.swift"
   s.resource_bundles = {
     "zcash-mainnet" => "ios/ZCashLightClientKit/Resources/checkpoints/mainnet/*.json",

--- a/scripts/updateSources.ts
+++ b/scripts/updateSources.ts
@@ -114,7 +114,7 @@ async function copySwift(): Promise<void> {
 
   // Copy the Rust header into the Swift location:
   await disklet.setText(
-    'ios/ZCashLightClientKit/Rust/zcashlc.h',
+    'ios/zcashlc.h',
     await disklet.getText(
       'tmp/zcash-light-client-ffi/releases/XCFramework/libzcashlc.xcframework/ios-arm64/libzcashlc.framework/Headers/zcashlc.h'
     )


### PR DESCRIPTION
Compiling with `use_frameworks!` exposes the fact that we forgot to include zcashlc.h in our podspec. Move it to a better location, then add it in.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

https://github.com/EdgeApp/react-native-piratechain/pull/12

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207384635316859