### PR TITLE
Consume Zcash SDK via Swift Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Consume the Zcash SDK (ZcashLightClientKit) via Swift Package Manager instead of vendoring its source and libzcashlc.xcframework into the pod. The host app adds the zcash-swift-wallet-sdk Swift Package; this package now ships only the React Native bridge, which imports ZcashLightClientKit from the SPM module. gRPC-Swift and SQLite.swift are no longer pod dependencies of this package.
+
 ## 0.12.1 (2026-06-18)
 
 - changed: Updated checkpoints

--- a/ios/RNZcash.swift
+++ b/ios/RNZcash.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import MnemonicSwift
 import SwiftProtobuf
+import ZcashLightClientKit
 import os
 
 actor SynchronizerStore {

--- a/ios/react-native-zcash-Bridging-Header.h
+++ b/ios/react-native-zcash-Bridging-Header.h
@@ -1,2 +1,1 @@
 #import <React/RCTEventEmitter.h>
-#include "zcashlc.h"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-zcash",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-zcash",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "biggystring": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zcash",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Zcash library for React Native",
   "homepage": "https://github.com/EdgeApp/react-native-zcash",
   "repository": {

--- a/react-native-zcash.podspec
+++ b/react-native-zcash.podspec
@@ -15,20 +15,16 @@ Pod::Spec.new do |s|
     :git => "https://github.com/EdgeApp/react-native-zcash.git",
     :tag => "v#{s.version}"
   }
+  # The Zcash SDK (ZcashLightClientKit) and its Rust FFI (libzcashlc), gRPC and
+  # SQLite are no longer vendored into this pod. They are consumed via Swift
+  # Package Manager (zcash-swift-wallet-sdk), added to the host app target. This
+  # pod ships only the React Native bridge, which imports ZcashLightClientKit
+  # from the SPM-provided module.
   s.source_files =
     "ios/react-native-zcash-Bridging-Header.h",
     "ios/RNZcash.m",
-    "ios/RNZcash.swift",
-    "ios/zcashlc.h",
-    "ios/ZCashLightClientKit/**/*.swift"
-  s.resource_bundles = {
-    "zcash-mainnet" => "ios/ZCashLightClientKit/Resources/checkpoints/mainnet/*.json",
-    "zcash-testnet" => "ios/ZCashLightClientKit/Resources/checkpoints/testnet/*.json"
-  }
-  s.vendored_frameworks = "ios/libzcashlc.xcframework"
+    "ios/RNZcash.swift"
 
   s.dependency "MnemonicSwift", "~> 2.2"
-  s.dependency "gRPC-Swift", "~> 1.8"
-  s.dependency "SQLite.swift/standalone", "~> 0.14"
   s.dependency "React-Core"
 end


### PR DESCRIPTION
## Summary

Migrate the iOS Zcash SDK (ZcashLightClientKit) from a vendored CocoaPods dependency to Swift Package Manager, per the Zcash SDK's move to SPM-only distribution.

- The pod no longer vendors the ZcashLightClientKit Swift source, `libzcashlc.xcframework`, or the gRPC-Swift / SQLite.swift pod dependencies. The host app adds `zcash-swift-wallet-sdk` (the official SDK) as a Swift Package; this package now ships only the React Native bridge.
- `RNZcash.swift` imports `ZcashLightClientKit` from the SPM module (previously the SDK was compiled into the same pod module, so no import was needed).
- Dropped the `zcashlc.h` include from the bridging header (the FFI is internal to the SPM SDK).
- Bumped to 0.13.0.

## Host-app integration (edge-react-gui)

The consuming app must add the `ZcashLightClientKit` Swift Package to its Xcode project and link it to the app target. Because CocoaPods still provides every other dependency, Pods and SPM coexist in the same project (CocoaPods 1.16 auto-mirrors the SPM product into the Pods project so the RN bridge pod can import the module).

## Status: DRAFT

This is not publishable/mergeable yet:
- The host-app SPM integration and a full iOS build + ZEC wallet sim test are still pending (see the host-app task).
- Known coexistence issue to resolve: `react-native-piratechain` still pulls `gRPC-Swift ~> 1.8` as a Pod while the SPM Zcash SDK pulls `grpc-swift 1.27.5` — under static linkage that collides. The clean fix is to also migrate piratechain's SDK (PirateLightClientKit, which is SPM-ready) to SPM so the resolver unifies the gRPC/NIO/SwiftProtobuf/SQLite graph.
- Follow-up: simplify `scripts/updateSources.ts` to stop vendoring the now-unused SDK source into the tarball.

https://claude.ai/code/session_019nYrjJ47fMBDnp9XdXT33g